### PR TITLE
fix: Fix typo on DEEP_THOUGHT__DB__URI

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -2,7 +2,7 @@ default: &default
   TZ: UTC
   DEEP_THOUGHT__LOG_LEVEL: INFO
   DEEP_THOUGHT__RAILS_LOG_TO_STDOUT: true
-  DEEP_THOUGHT__DB_URI: mongodb://localhost:27017/deep_thought
+  DEEP_THOUGHT__DB__URI: mongodb://localhost:27017/deep_thought
   DEEP_THOUGHT__PROTOCOL: http
   DEEP_THOUGHT__PORT: 3000
   DEEP_THOUGHT__HOSTNAME: deepthought.localhost.com
@@ -18,7 +18,7 @@ default: &default
 test: &test
   <<: *default
   DEEP_THOUGHT__LOG_LEVEL: ERROR
-  DEEP_THOUGHT__DB_URI: mongodb://localhost:27017/deep_thought_test
+  DEEP_THOUGHT__DB__URI: mongodb://localhost:27017/deep_thought_test
 development: &development
   <<: *default
   DEEP_THOUGHT__LOG_LEVEL: DEBUG

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,11 +5,12 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: deep_thought_development
-      # Provides the hosts the default client can connect to. Must be an array
-      # of host:port pairs. (required)
-      hosts:
-        - localhost:27017
+      # database: deep_thought_development
+      # # Provides the hosts the default client can connect to. Must be an array
+      # # of host:port pairs. (required)
+      # hosts:
+      #   - localhost:27017
+      uri: <%= ENV['DEEP_THOUGHT__DB__URI'] %>
       options:
         # Note that all options listed below are Ruby driver client options (the mongo gem).
         # Please refer to the driver documentation of the version of the mongo gem you are using

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ services:
     build: .
     environment:
       RAILS_ENV: 'development' 
-      DEEP_THOUGHT__LOG_LEVEL: 'INFO' # ERROR, WARNING, INFO, DEBUG
+      DEEP_THOUGHT__LOG_LEVEL: 'DEBUG' # ERROR, WARNING, INFO, DEBUG
       DEEP_THOUGHT__RAILS_LOG_TO_STDOUT: 'true' # true | false
-      DEEP_THOUGHT__DB_URI: 'mongodb://deep_thought:deep_thought@deep-thought-db:27017/deep_thought'
+      DEEP_THOUGHT__DB__URI: 'mongodb://deep_thought:deep_thought@deep-thought-db:27017/deep_thought?authSource=admin'
       DEEP_THOUGHT__PROTOCOL: 'http'
       DEEP_THOUGHT__PORT: 3000
       DEEP_THOUGHT__HOSTNAME: 'deepthought.localhost.com'


### PR DESCRIPTION
- Correção na variável `DEEP_THOUGHT__DB__URI`
- Adicionado parâmetro `authSource` a URI do mongodb
- Adicionando variável de ambiente na chave `uri` em `mongoid.yml` no lugar de configurar por host e database.

Ref: [mongodb#authentication-options](https://docs.mongodb.com/manual/reference/connection-string/#authentication-options)